### PR TITLE
Fix typo in "Sets, Functions and Relations"

### DIFF
--- a/html/_sources/sets_functions_and_relations.rst.txt
+++ b/html/_sources/sets_functions_and_relations.rst.txt
@@ -802,7 +802,7 @@ If ``f : α → β`` is a function and  ``p`` is a set of
 elements of type ``β``,
 the library defines ``preimage f p``, written ``f ⁻¹' p``,
 to be ``{x | f x ∈ p}``.
-The expression ``x ∈ f ⁻¹' p`` reduces to ``f x ∈ s``.
+The expression ``x ∈ f ⁻¹' p`` reduces to ``f x ∈ p``.
 This is often convenient, as in the following example:
 
 .. code-block:: lean


### PR DESCRIPTION
When I was reading through found this tiny typo. Confused me for a while what `s` was!