### PR TITLE
feat: require 4 CPUs and 8GB memory for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,11 @@
 
   "onCreateCommand": "echo \"Downloading the Lean 4 mathematical library...\" && lake exe cache get! && lake build +MIL.Common && echo \"Finished setup! Open a file using the Explorer in the top-left of your screen.\"",
 
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb"
+  },
+
   "customizations": {
     "vscode" : {
       "extensions" : [ "leanprover.lean4" ]


### PR DESCRIPTION
This PR adds a `hostRequirements` block to `.devcontainer/devcontainer.json` requesting 4 CPUs and 8GB of memory, matching the configuration already used in [mathlib4's devcontainer](https://github.com/leanprover-community/mathlib4/blob/master/.devcontainer/devcontainer.json).

Without this, GitHub Codespaces defaults to a 2-core machine, which Dan Velleman reports is too slow for MIL in practice — switching to the 4-core machine type makes a substantial difference. See the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Github.20Codespaces/near/597018464).

🤖 Prepared with Claude Code